### PR TITLE
docs: update README to remove outdated template info

### DIFF
--- a/cfg/README.md
+++ b/cfg/README.md
@@ -5,5 +5,4 @@
 |:-:|:-:|
 | Custom_Clash.ini | 搭配 OpenClash 绕过大陆功能使用的订阅转换模板 |
 | Custom_Clash_Mainland.ini | 添加了 GitHub 反代地址的订阅模板，适合架设在中国大陆地区的订阅转换服务使用 |
-| Custom_Clash_GeoSite.ini | 添加了 GeoSite CN 区域网站直连规则，无需绕过大陆功能的订阅转换模板 |
 | Custom_Clash_Test.ini | 测试用订阅转换模板，请勿使用 |


### PR DESCRIPTION
Remove the entry for Custom_Clash_GeoSite.ini from the README. This  change reflects the removal of the outdated subscription conversion  template that is no longer necessary.