### PR TITLE
增加 GoLink 加速器直连

### DIFF
--- a/rule/Custom_Direct.list
+++ b/rule/Custom_Direct.list
@@ -111,3 +111,5 @@ DOMAIN-SUFFIX,bdcat.top
 DOMAIN-SUFFIX,ningtingche.com
 # GUOO 物流
 DOMAIN-SUFFIX,guoocang.com
+# GoLink 加速器
+DOMAIN-SUFFIX,golinkapi.com


### PR DESCRIPTION
GoLink 加速器会通过用户网络判断进入国内版还是海外版，所以需要直连才能进入国内版正常加速