### PR TITLE
添加国内冷门域名-智慧笑联

### DIFF
--- a/rule/Custom_Direct.list
+++ b/rule/Custom_Direct.list
@@ -104,3 +104,5 @@ DOMAIN-SUFFIX,ningtingche.com
 DOMAIN-SUFFIX,guoocang.com
 # GoLink 加速器
 DOMAIN-SUFFIX,golinkapi.com
+# 智慧笑联
+DOMAIN-SUFFIX,xiaolianhb.com


### PR DESCRIPTION
此域名为部分高校宿舍公共洗衣机控制app所属，已确定为国内ip
![0C075DF45099627D0F6060A7444BA554](https://github.com/user-attachments/assets/b4e3e6c4-b857-40c4-8595-b1af67290c56)
