### PR TITLE
[广告拦截]修复 reload 指令不加载新规则的问题

### DIFF
--- a/script/ad-block.txt
+++ b/script/ad-block.txt
@@ -85,7 +85,8 @@
     # 输出清理 DNS 缓存的日志
     LOG_OUT "[广告过滤规则拉取脚本] 清理 DNS 缓存…"
     # 重新加载 dnsmasq 服务以应用新的规则
-    /etc/init.d/dnsmasq reload
+    /etc/init.d/dnsmasq stop
+    /etc/init.d/dnsmasq start    
     # 输出脚本运行完毕的日志
     LOG_OUT "[广告过滤规则拉取脚本] 脚本运行完毕！"
 

--- a/shell/edit_custom_firewall_rules.sh
+++ b/shell/edit_custom_firewall_rules.sh
@@ -191,7 +191,8 @@ if [ "$adv_choice" = "y" ] || [ "$github_choice" = "y" ]; then
     fi
     NEW_INSERT_CONTENT="${NEW_INSERT_CONTENT}
     LOG_OUT \"[广告过滤规则拉取脚本] 清理 DNS 缓存...\"
-    /etc/init.d/dnsmasq reload
+    /etc/init.d/dnsmasq stop
+    /etc/init.d/dnsmasq start
     LOG_OUT \"[广告过滤规则拉取脚本] 脚本运行完毕!\"
 
 ) &

--- a/shell/edit_custom_firewall_rules_adblockfilters+github520.sh
+++ b/shell/edit_custom_firewall_rules_adblockfilters+github520.sh
@@ -60,7 +60,8 @@ INSERT_CONTENT=$(cat << EOF
     sed -i '/!/d' /etc/hosts
 
     LOG_OUT "[广告过滤规则拉取脚本] 清理 DNS 缓存…"
-    /etc/init.d/dnsmasq reload
+    /etc/init.d/dnsmasq stop
+    /etc/init.d/dnsmasq start
     LOG_OUT "[广告过滤规则拉取脚本] 脚本运行完毕！"
 
 ) &

--- a/shell/edit_custom_firewall_rules_adblockfilters-modified+github520.sh
+++ b/shell/edit_custom_firewall_rules_adblockfilters-modified+github520.sh
@@ -60,7 +60,8 @@ INSERT_CONTENT=$(cat << EOF
     sed -i '/!/d' /etc/hosts
 
     LOG_OUT "[广告过滤规则拉取脚本] 清理 DNS 缓存…"
-    /etc/init.d/dnsmasq reload
+    /etc/init.d/dnsmasq stop
+    /etc/init.d/dnsmasq start
     LOG_OUT "[广告过滤规则拉取脚本] 脚本运行完毕！"
 
 ) &

--- a/shell/edit_custom_firewall_rules_anti-ad+github520.sh
+++ b/shell/edit_custom_firewall_rules_anti-ad+github520.sh
@@ -59,7 +59,8 @@ INSERT_CONTENT=$(cat << EOF
     sed -i '/!/d' /etc/hosts
 
     LOG_OUT "[广告过滤规则拉取脚本] 清理 DNS 缓存…"
-    /etc/init.d/dnsmasq reload
+    /etc/init.d/dnsmasq stop
+    /etc/init.d/dnsmasq start
     LOG_OUT "[广告过滤规则拉取脚本] 脚本运行完毕！"
 
 ) &


### PR DESCRIPTION
## 修复
尝试解决当执行`reload`命令后（清理DNS缓存），无法加载`/tmp/dnsmasq.d`目录中新添加的`.conf`文件（去广告规则）的问题。根本原因可能在于`reload`命令仅重新读取已加载的配置文件，而不会重新扫描`dnsmasq.d`目录以检测新文件。当设备重启后（tmp被清空），便无法加载刚下载的去广告规则，导致去广告完全失效，直到用户手动重启openclash。为了确保新配置每次都能正确加载，服务必须完全重启（先stop后start）。
## 验证
### 修改前
---
![PixPin_2025-03-02_20-45-00](https://github.com/user-attachments/assets/6ad43138-36f2-4dbc-a436-e9526133064e)
![PixPin_2025-03-02_20-42-44](https://github.com/user-attachments/assets/792cee5d-fd7e-4db2-8dc3-d2b800160deb)
---
### 修改后
---
![image](https://github.com/user-attachments/assets/91531bb0-e920-46c2-81ec-42448d6f6350)
---
## 测试版本
[Meta] 最新dev内核版本 `alpha-g05e8f13`
最新客户端版本 `v0.46.077`



