### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reject_cfg_prs.yml
+++ b/.github/workflows/reject_cfg_prs.yml
@@ -1,5 +1,9 @@
 name: Reject CFG Directory PRs
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
Potential fix for [https://github.com/Aethersailor/Custom_OpenClash_Rules/security/code-scanning/6](https://github.com/Aethersailor/Custom_OpenClash_Rules/security/code-scanning/6)

The fix requires adding a `permissions` block limiting the workflow to the least required privileges. In this case, since the workflow utilizes the `gh pr comment` and `gh pr close` commands, it needs permission to write pull requests. Reading PRs and listing files are possible with `pull-requests: read`, but commenting and closing a PR require `pull-requests: write`. The workflow does not appear to require write access to repository contents, so `contents: read` is sufficient. The best practice is to add this `permissions` block at the top level of the workflow (after the `name` and before `on`), so it applies to all jobs by default. This is both the least-privilege and easiest maintenance configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
