### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/purge-jsdelivr.yml
+++ b/.github/workflows/purge-jsdelivr.yml
@@ -20,6 +20,8 @@ on:
 jobs:
   purge-jsdelivr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     continue-on-error: true
     defaults:
       run:


### PR DESCRIPTION
Potential fix for [https://github.com/Aethersailor/Custom_OpenClash_Rules/security/code-scanning/7](https://github.com/Aethersailor/Custom_OpenClash_Rules/security/code-scanning/7)

To fix the problem, explicitly define a `permissions:` block that grants only the minimal required scope for this job. This workflow checks out the repository and runs `git fetch` but otherwise only calls an external URL, so it only needs read access to repository contents via `GITHUB_TOKEN`.

The best fix without changing existing functionality is:

- Add a `permissions:` section under the `purge-jsdelivr` job (so it affects only this job and not other workflows).
- Set `contents: read` to allow `actions/checkout` and subsequent `git` operations to function.
- Do not add any write permissions, since the job does not use them.

Concretely, in `.github/workflows/purge-jsdelivr.yml`, insert:

```yaml
    permissions:
      contents: read
```

immediately under `runs-on: ubuntu-latest` (and before `continue-on-error:`). No new imports, actions, or methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
