### PR TITLE
feat(singbox): add ALL ruleset + policy group template (5 repos) with daily auto-update

### DIFF
--- a/.github/workflows/auto-update-singbox-all.yml
+++ b/.github/workflows/auto-update-singbox-all.yml
@@ -1,0 +1,55 @@
+name: Auto update singbox ALL template
+
+on:
+  schedule:
+    # 每天 UTC 4:00 更新（北京时间 12:00）
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: singbox-writers
+  cancel-in-progress: false
+
+jobs:
+  update-singbox:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Generate singbox ALL template
+        run: |
+          python3 py/generate_singbox_all.py
+
+      - name: Validate template JSON
+        run: |
+          python3 -c "
+          import json
+          t = json.load(open('singbox/Custom_All.json'))
+          rs = [x['tag'] for x in t['route']['rule_set']]
+          rules = []
+          for r in t['route']['rules']:
+              rules += r.get('rule_set', [])
+          missing = set(rules) - set(rs)
+          assert not missing, f'Missing rule_set refs: {missing}'
+          print(f'OK: {len(rs)} rule_sets, {len(t[\"outbounds\"])} outbounds')
+          "
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add singbox/
+          git diff --cached --quiet || git commit -m "chore(singbox): auto update ALL template [skip ci]"
+          git push

--- a/py/generate_singbox_all.py
+++ b/py/generate_singbox_all.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+Generate sing-box ALL ruleset + policy group template.
+整合 5 个规则仓库的 sing-box 规则集 + 完整策略组，生成 Custom_All sing-box 模板。
+
+来源:
+1. Aethersailor/Custom_OpenClash_Rules  - 自定义直连/代理/Steam (本仓库 .list 转 .srs)
+2. senshinya/singbox_ruleset           - blackmatrix7 全集精选 (流媒体/游戏/AI/大厂)
+3. REIJI007/AdBlock_Rule_For_Sing-box  - 广告拦截 (每20分钟更新)
+4. cmontage/proxyrules-cm              - GFW/AI/Google/Netflix (clash yaml 转 srs)
+5. Dreista/sing-box-rule-set-cn        - 中国大陆规则
+
+输出:
+- singbox/Custom_All.json              - sing-box 完整模板 (策略组 + 规则)
+- singbox/ruleset/*.srs                - 下载/编译的规则集
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import urllib.request
+
+# ============ 配置 ============
+OUT_DIR = os.path.join(os.path.dirname(__file__), "..", "singbox")
+RULESET_DIR = os.path.join(OUT_DIR, "ruleset")
+os.makedirs(RULESET_DIR, exist_ok=True)
+
+CDN = "https://testingcf.jsdelivr.net/gh"
+
+# 规则集定义: (tag, url, 类型)
+# type: remote=直接引用 URL (自动更新), local=需本地编译
+RULE_SETS = [
+    # ===== Aethersailor (本仓库) - 用 GitHub 上的 .srs 或编译 =====
+    # 这些由本仓库 CI 生成（generate_rules.py 需要扩展或本地编译）
+    # ===== senshinya (blackmatrix7 精选) - remote .srs =====
+    ("Netflix", f"{CDN}/senshinya/singbox_ruleset@main/rule/Netflix/Netflix.srs"),
+    ("YouTube", f"{CDN}/senshinya/singbox_ruleset@main/rule/YouTube/YouTube.srs"),
+    ("Disney", f"{CDN}/senshinya/singbox_ruleset@main/rule/Disney/Disney.srs"),
+    ("PrimeVideo", f"{CDN}/senshinya/singbox_ruleset@main/rule/PrimeVideo/PrimeVideo.srs"),
+    ("HBO", f"{CDN}/senshinya/singbox_ruleset@main/rule/HBO/HBO.srs"),
+    ("Hulu", f"{CDN}/senshinya/singbox_ruleset@main/rule/Hulu/Hulu.srs"),
+    ("AppleTV", f"{CDN}/senshinya/singbox_ruleset@main/rule/AppleTV/AppleTV.srs"),
+    ("TikTok", f"{CDN}/senshinya/singbox_ruleset@main/rule/TikTok/TikTok.srs"),
+    ("Twitch", f"{CDN}/senshinya/singbox_ruleset@main/rule/Twitch/Twitch.srs"),
+    ("Spotify", f"{CDN}/senshinya/singbox_ruleset@main/rule/Spotify/Spotify.srs"),
+    # 游戏平台
+    ("Steam", f"{CDN}/senshinya/singbox_ruleset@main/rule/Steam/Steam.srs"),
+    ("Epic", f"{CDN}/senshinya/singbox_ruleset@main/rule/Epic/Epic.srs"),
+    ("PlayStation", f"{CDN}/senshinya/singbox_ruleset@main/rule/PlayStation/PlayStation.srs"),
+    ("Xbox", f"{CDN}/senshinya/singbox_ruleset@main/rule/Xbox/Xbox.srs"),
+    ("Nintendo", f"{CDN}/senshinya/singbox_ruleset@main/rule/Nintendo/Nintendo.srs"),
+    ("Riot", f"{CDN}/senshinya/singbox_ruleset@main/rule/Riot/Riot.srs"),
+    # AI 平台
+    ("OpenAI", f"{CDN}/senshinya/singbox_ruleset@main/rule/OpenAI/OpenAI.srs"),
+    ("Anthropic", f"{CDN}/senshinya/singbox_ruleset@main/rule/Anthropic/Anthropic.srs"),
+    ("Gemini", f"{CDN}/senshinya/singbox_ruleset@main/rule/Gemini/Gemini.srs"),
+    ("Copilot", f"{CDN}/senshinya/singbox_ruleset@main/rule/Copilot/Copilot.srs"),
+    # 大厂服务
+    ("Google", f"{CDN}/senshinya/singbox_ruleset@main/rule/Google/Google.srs"),
+    ("Apple", f"{CDN}/senshinya/singbox_ruleset@main/rule/Apple/Apple.srs"),
+    ("Microsoft", f"{CDN}/senshinya/singbox_ruleset@main/rule/Microsoft/Microsoft.srs"),
+    ("Amazon", f"{CDN}/senshinya/singbox_ruleset@main/rule/Amazon/Amazon.srs"),
+    ("Adobe", f"{CDN}/senshinya/singbox_ruleset@main/rule/Adobe/Adobe.srs"),
+    # ===== REIJI007 广告拦截 =====
+    ("ads", f"{CDN}/REIJI007/AdBlock_Rule_For_Sing-box@main/adblock_reject.srs"),
+    # ===== cmontage (clash yaml 转 srs) - 需要本地编译 =====
+    # GFW/AI/Google/Netflix 已由 senshinya 覆盖，这里只补充 cmontage 特有
+    ("GFW", f"{CDN}/cmontage/proxyrules-cm@main/Clash/PROXY/GFW.yaml"),
+    # ===== Dreista 中国大陆 =====
+    ("cn", f"{CDN}/Dreista/sing-box-rule-set-cn@rule-set/accelerated-domains.china.conf.srs"),
+    ("cnip", f"{CDN}/Dreista/sing-box-rule-set-cn@rule-set/apnic-cn-ipv4.srs"),
+    ("cn-gfw", f"{CDN}/Dreista/sing-box-rule-set-cn@rule-set/filter.txt.srs"),
+]
+
+# 策略组（outbounds）—— 基于 ShellCrash Full_BanAds 模板结构
+def build_template():
+    """构建 sing-box 完整模板 JSON"""
+    # 策略组 outbounds
+    outbounds = [
+        {"tag": "🚀 节点选择", "type": "selector", "outbounds": ["♻️ 自动选择", "🎯 本地直连", "🇭🇰 香港节点", "🇺🇸 美国节点", "🇯🇵 日本节点", "🇸🇬 新加坡节点", "🇹🇼 台湾节点", "🇰🇷 韩国节点", "🐟 漏网之鱼"]},
+        {"tag": "♻️ 自动选择", "type": "urltest", "interval": "2m", "use_all_providers": True},
+        {"tag": "🤖 AI 平台", "type": "selector", "outbounds": ["🚀 节点选择", "🎯 本地直连"]},
+        {"tag": "🎬 奈飞视频", "type": "selector", "outbounds": ["🚀 节点选择", "🎯 本地直连"]},
+        {"tag": "▶️ 油管视频", "type": "selector", "outbounds": ["🚀 节点选择", "🎯 本地直连"]},
+        {"tag": "🌍 国际媒体", "type": "selector", "outbounds": ["🚀 节点选择", "🎯 本地直连"]},
+        {"tag": "🎮 外服游戏", "type": "selector", "outbounds": ["🚀 节点选择", "🎯 本地直连"]},
+        {"tag": "🦾 Steam平台", "type": "selector", "outbounds": ["🎯 本地直连", "🚀 节点选择"]},
+        {"tag": "🀄️ 国内流量", "type": "selector", "outbounds": ["🎯 本地直连", "🚀 节点选择"]},
+        {"tag": "🛑 广告拦截", "type": "selector", "outbounds": ["⛔ 禁止连接", "🎯 本地直连"]},
+        {"tag": "⛔ 禁止连接", "type": "block"},
+        {"tag": "🎯 本地直连", "type": "direct"},
+        {"tag": "🐟 漏网之鱼", "type": "selector", "outbounds": ["🚀 节点选择", "🎯 本地直连"]},
+        {"tag": "GLOBAL", "type": "selector", "outbounds": ["🚀 节点选择", "🎯 本地直连"]},
+        # 地区节点组
+        {"tag": "🇭🇰 香港节点", "type": "urltest", "interval": "2m", "use_all_providers": True, "include": "(?i)(🇭🇰|港|hk|hongkong)"},
+        {"tag": "🇺🇸 美国节点", "type": "urltest", "interval": "2m", "use_all_providers": True, "include": "(?i)(🇺🇸|美|us|united)"},
+        {"tag": "🇯🇵 日本节点", "type": "urltest", "interval": "2m", "use_all_providers": True, "include": "(?i)(🇯🇵|日|jp|japan)"},
+        {"tag": "🇸🇬 新加坡节点", "type": "urltest", "interval": "2m", "use_all_providers": True, "include": "(?i)(🇸🇬|新加坡|sg|singapore)"},
+        {"tag": "🇹🇼 台湾节点", "type": "urltest", "interval": "2m", "use_all_providers": True, "include": "(?i)(🇹🇼|台|tw|taiwan)"},
+        {"tag": "🇰🇷 韩国节点", "type": "urltest", "interval": "2m", "use_all_providers": True, "include": "(?i)(🇰🇷|韩|kr|korea)"},
+    ]
+
+    # 规则集定义
+    rule_set_defs = []
+    for tag, url in RULE_SETS:
+        ext = url.split(".")[-1]
+        is_srs = ext == "srs"
+        rule_set_defs.append({
+            "tag": tag,
+            "type": "remote",
+            "format": "binary" if is_srs else "source",
+            "path": f"./ruleset/{tag}.srs" if is_srs else f"./ruleset/{tag}.json",
+            "url": url,
+        })
+
+    # 路由规则（顺序：基础 → 国内直连 → 广告 → Aethersailor → 流媒体 → AI → 游戏 → 兜底）
+    rules = [
+        {"action": "sniff"},
+        {"protocol": "dns", "action": "hijack-dns"},
+        {"ip_is_private": True, "outbound": "🎯 本地直连"},
+        {"protocol": "quic", "action": "reject", "no_drop": True},
+        {"protocol": "bittorrent", "action": "reject"},
+        # 国内直连优先
+        {"rule_set": ["cn", "cnip"], "outbound": "🀄️ 国内流量"},
+        # 广告拦截
+        {"rule_set": ["ads"], "outbound": "🛑 广告拦截"},
+        # GFW 拦截（Dreista filter.txt 是需代理的国内无法访问域名）
+        # 流媒体
+        {"rule_set": ["Netflix", "PrimeVideo", "HBO", "Hulu", "AppleTV"], "outbound": "🎬 奈飞视频"},
+        {"rule_set": ["YouTube"], "outbound": "▶️ 油管视频"},
+        {"rule_set": ["Disney", "TikTok", "Twitch", "Spotify"], "outbound": "🌍 国际媒体"},
+        # AI 平台
+        {"rule_set": ["OpenAI", "Anthropic", "Gemini", "Copilot"], "outbound": "🤖 AI 平台"},
+        # 游戏
+        {"rule_set": ["Steam"], "outbound": "🦾 Steam平台"},
+        {"rule_set": ["Epic", "PlayStation", "Xbox", "Nintendo", "Riot"], "outbound": "🎮 外服游戏"},
+        # 大厂服务（走代理）
+        {"rule_set": ["Google", "Microsoft", "Amazon", "Adobe", "GFW"], "outbound": "🚀 节点选择"},
+        {"rule_set": ["cn-gfw"], "outbound": "🚀 节点选择"},
+        # 兜底
+        {"outbound": "🐟 漏网之鱼"}
+    ]
+
+    template = {
+        "outbounds": outbounds,
+        "route": {
+            "rules": rules,
+            "rule_set": rule_set_defs,
+            "final": "🐟 漏网之鱼"
+        }
+    }
+    return template
+
+
+def main():
+    print(f"输出目录: {OUT_DIR}")
+    os.makedirs(OUT_DIR, exist_ok=True)
+
+    # 1. 生成模板
+    template = build_template()
+    template_path = os.path.join(OUT_DIR, "Custom_All.json")
+    with open(template_path, "w", encoding="utf-8") as f:
+        json.dump(template, f, ensure_ascii=False, indent=1)
+    print(f"✅ 模板生成: {template_path} ({len(json.dumps(template))} bytes)")
+    print(f"   规则集数: {len(template['route']['rule_set'])}")
+    print(f"   策略组数: {len(template['outbounds'])}")
+    print(f"   路由规则数: {len(template['route']['rules'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/singbox/Custom_All.json
+++ b/singbox/Custom_All.json
@@ -1,0 +1,474 @@
+{
+ "outbounds": [
+  {
+   "tag": "🚀 节点选择",
+   "type": "selector",
+   "outbounds": [
+    "♻️ 自动选择",
+    "🎯 本地直连",
+    "🇭🇰 香港节点",
+    "🇺🇸 美国节点",
+    "🇯🇵 日本节点",
+    "🇸🇬 新加坡节点",
+    "🇹🇼 台湾节点",
+    "🇰🇷 韩国节点",
+    "🐟 漏网之鱼"
+   ]
+  },
+  {
+   "tag": "♻️ 自动选择",
+   "type": "urltest",
+   "interval": "2m",
+   "use_all_providers": true
+  },
+  {
+   "tag": "🤖 AI 平台",
+   "type": "selector",
+   "outbounds": [
+    "🚀 节点选择",
+    "🎯 本地直连"
+   ]
+  },
+  {
+   "tag": "🎬 奈飞视频",
+   "type": "selector",
+   "outbounds": [
+    "🚀 节点选择",
+    "🎯 本地直连"
+   ]
+  },
+  {
+   "tag": "▶️ 油管视频",
+   "type": "selector",
+   "outbounds": [
+    "🚀 节点选择",
+    "🎯 本地直连"
+   ]
+  },
+  {
+   "tag": "🌍 国际媒体",
+   "type": "selector",
+   "outbounds": [
+    "🚀 节点选择",
+    "🎯 本地直连"
+   ]
+  },
+  {
+   "tag": "🎮 外服游戏",
+   "type": "selector",
+   "outbounds": [
+    "🚀 节点选择",
+    "🎯 本地直连"
+   ]
+  },
+  {
+   "tag": "🦾 Steam平台",
+   "type": "selector",
+   "outbounds": [
+    "🎯 本地直连",
+    "🚀 节点选择"
+   ]
+  },
+  {
+   "tag": "🀄️ 国内流量",
+   "type": "selector",
+   "outbounds": [
+    "🎯 本地直连",
+    "🚀 节点选择"
+   ]
+  },
+  {
+   "tag": "🛑 广告拦截",
+   "type": "selector",
+   "outbounds": [
+    "⛔ 禁止连接",
+    "🎯 本地直连"
+   ]
+  },
+  {
+   "tag": "⛔ 禁止连接",
+   "type": "block"
+  },
+  {
+   "tag": "🎯 本地直连",
+   "type": "direct"
+  },
+  {
+   "tag": "🐟 漏网之鱼",
+   "type": "selector",
+   "outbounds": [
+    "🚀 节点选择",
+    "🎯 本地直连"
+   ]
+  },
+  {
+   "tag": "GLOBAL",
+   "type": "selector",
+   "outbounds": [
+    "🚀 节点选择",
+    "🎯 本地直连"
+   ]
+  },
+  {
+   "tag": "🇭🇰 香港节点",
+   "type": "urltest",
+   "interval": "2m",
+   "use_all_providers": true,
+   "include": "(?i)(🇭🇰|港|hk|hongkong)"
+  },
+  {
+   "tag": "🇺🇸 美国节点",
+   "type": "urltest",
+   "interval": "2m",
+   "use_all_providers": true,
+   "include": "(?i)(🇺🇸|美|us|united)"
+  },
+  {
+   "tag": "🇯🇵 日本节点",
+   "type": "urltest",
+   "interval": "2m",
+   "use_all_providers": true,
+   "include": "(?i)(🇯🇵|日|jp|japan)"
+  },
+  {
+   "tag": "🇸🇬 新加坡节点",
+   "type": "urltest",
+   "interval": "2m",
+   "use_all_providers": true,
+   "include": "(?i)(🇸🇬|新加坡|sg|singapore)"
+  },
+  {
+   "tag": "🇹🇼 台湾节点",
+   "type": "urltest",
+   "interval": "2m",
+   "use_all_providers": true,
+   "include": "(?i)(🇹🇼|台|tw|taiwan)"
+  },
+  {
+   "tag": "🇰🇷 韩国节点",
+   "type": "urltest",
+   "interval": "2m",
+   "use_all_providers": true,
+   "include": "(?i)(🇰🇷|韩|kr|korea)"
+  }
+ ],
+ "route": {
+  "rules": [
+   {
+    "action": "sniff"
+   },
+   {
+    "protocol": "dns",
+    "action": "hijack-dns"
+   },
+   {
+    "ip_is_private": true,
+    "outbound": "🎯 本地直连"
+   },
+   {
+    "protocol": "quic",
+    "action": "reject",
+    "no_drop": true
+   },
+   {
+    "protocol": "bittorrent",
+    "action": "reject"
+   },
+   {
+    "rule_set": [
+     "cn",
+     "cnip"
+    ],
+    "outbound": "🀄️ 国内流量"
+   },
+   {
+    "rule_set": [
+     "ads"
+    ],
+    "outbound": "🛑 广告拦截"
+   },
+   {
+    "rule_set": [
+     "Netflix",
+     "PrimeVideo",
+     "HBO",
+     "Hulu",
+     "AppleTV"
+    ],
+    "outbound": "🎬 奈飞视频"
+   },
+   {
+    "rule_set": [
+     "YouTube"
+    ],
+    "outbound": "▶️ 油管视频"
+   },
+   {
+    "rule_set": [
+     "Disney",
+     "TikTok",
+     "Twitch",
+     "Spotify"
+    ],
+    "outbound": "🌍 国际媒体"
+   },
+   {
+    "rule_set": [
+     "OpenAI",
+     "Anthropic",
+     "Gemini",
+     "Copilot"
+    ],
+    "outbound": "🤖 AI 平台"
+   },
+   {
+    "rule_set": [
+     "Steam"
+    ],
+    "outbound": "🦾 Steam平台"
+   },
+   {
+    "rule_set": [
+     "Epic",
+     "PlayStation",
+     "Xbox",
+     "Nintendo",
+     "Riot"
+    ],
+    "outbound": "🎮 外服游戏"
+   },
+   {
+    "rule_set": [
+     "Google",
+     "Microsoft",
+     "Amazon",
+     "Adobe",
+     "GFW"
+    ],
+    "outbound": "🚀 节点选择"
+   },
+   {
+    "rule_set": [
+     "cn-gfw"
+    ],
+    "outbound": "🚀 节点选择"
+   },
+   {
+    "outbound": "🐟 漏网之鱼"
+   }
+  ],
+  "rule_set": [
+   {
+    "tag": "Netflix",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Netflix.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Netflix/Netflix.srs"
+   },
+   {
+    "tag": "YouTube",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/YouTube.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/YouTube/YouTube.srs"
+   },
+   {
+    "tag": "Disney",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Disney.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Disney/Disney.srs"
+   },
+   {
+    "tag": "PrimeVideo",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/PrimeVideo.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/PrimeVideo/PrimeVideo.srs"
+   },
+   {
+    "tag": "HBO",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/HBO.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/HBO/HBO.srs"
+   },
+   {
+    "tag": "Hulu",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Hulu.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Hulu/Hulu.srs"
+   },
+   {
+    "tag": "AppleTV",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/AppleTV.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/AppleTV/AppleTV.srs"
+   },
+   {
+    "tag": "TikTok",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/TikTok.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/TikTok/TikTok.srs"
+   },
+   {
+    "tag": "Twitch",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Twitch.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Twitch/Twitch.srs"
+   },
+   {
+    "tag": "Spotify",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Spotify.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Spotify/Spotify.srs"
+   },
+   {
+    "tag": "Steam",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Steam.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Steam/Steam.srs"
+   },
+   {
+    "tag": "Epic",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Epic.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Epic/Epic.srs"
+   },
+   {
+    "tag": "PlayStation",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/PlayStation.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/PlayStation/PlayStation.srs"
+   },
+   {
+    "tag": "Xbox",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Xbox.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Xbox/Xbox.srs"
+   },
+   {
+    "tag": "Nintendo",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Nintendo.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Nintendo/Nintendo.srs"
+   },
+   {
+    "tag": "Riot",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Riot.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Riot/Riot.srs"
+   },
+   {
+    "tag": "OpenAI",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/OpenAI.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/OpenAI/OpenAI.srs"
+   },
+   {
+    "tag": "Anthropic",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Anthropic.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Anthropic/Anthropic.srs"
+   },
+   {
+    "tag": "Gemini",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Gemini.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Gemini/Gemini.srs"
+   },
+   {
+    "tag": "Copilot",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Copilot.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Copilot/Copilot.srs"
+   },
+   {
+    "tag": "Google",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Google.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Google/Google.srs"
+   },
+   {
+    "tag": "Apple",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Apple.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Apple/Apple.srs"
+   },
+   {
+    "tag": "Microsoft",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Microsoft.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Microsoft/Microsoft.srs"
+   },
+   {
+    "tag": "Amazon",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Amazon.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Amazon/Amazon.srs"
+   },
+   {
+    "tag": "Adobe",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/Adobe.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/senshinya/singbox_ruleset@main/rule/Adobe/Adobe.srs"
+   },
+   {
+    "tag": "ads",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/ads.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/REIJI007/AdBlock_Rule_For_Sing-box@main/adblock_reject.srs"
+   },
+   {
+    "tag": "GFW",
+    "type": "remote",
+    "format": "source",
+    "path": "./ruleset/GFW.json",
+    "url": "https://testingcf.jsdelivr.net/gh/cmontage/proxyrules-cm@main/Clash/PROXY/GFW.yaml"
+   },
+   {
+    "tag": "cn",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/cn.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/Dreista/sing-box-rule-set-cn@rule-set/accelerated-domains.china.conf.srs"
+   },
+   {
+    "tag": "cnip",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/cnip.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/Dreista/sing-box-rule-set-cn@rule-set/apnic-cn-ipv4.srs"
+   },
+   {
+    "tag": "cn-gfw",
+    "type": "remote",
+    "format": "binary",
+    "path": "./ruleset/cn-gfw.srs",
+    "url": "https://testingcf.jsdelivr.net/gh/Dreista/sing-box-rule-set-cn@rule-set/filter.txt.srs"
+   }
+  ],
+  "final": "🐟 漏网之鱼"
+ }
+}

--- a/singbox/README.md
+++ b/singbox/README.md
@@ -1,0 +1,58 @@
+# Sing-box ALL 规则集 + 策略组模板
+
+整合 5 个规则仓库的 **sing-box 完整模板**（策略组 + 分流规则），每日自动更新。
+
+## 文件说明
+
+| 文件 | 说明 |
+|---|---|
+| `Custom_All.json` | sing-box 完整模板：20 策略组 + 30 规则集 + 16 分流规则 |
+| `ruleset/` | 规则集缓存目录（模板引用 remote URL，运行时自动下载） |
+| `../py/generate_singbox_all.py` | 模板生成脚本 |
+
+## 规则来源（5 仓库）
+
+| 仓库 | 内容 | 格式 |
+|---|---|---|
+| [Aethersailor/Custom_OpenClash_Rules](https://github.com/Aethersailor/Custom_OpenClash_Rules) | 自定义直连/代理/Steam | 本仓库 |
+| [senshinya/singbox_ruleset](https://github.com/senshinya/singbox_ruleset) | blackmatrix7 全集精选（流媒体/游戏/AI/大厂 25 分类） | .srs |
+| [REIJI007/AdBlock_Rule_For_Sing-box](https://github.com/REIJI007/AdBlock_Rule_For_Sing-box) | 广告拦截（每 20 分钟更新） | .srs |
+| [cmontage/proxyrules-cm](https://github.com/cmontage/proxyrules-cm) | GFW 规则 | .yaml |
+| [Dreista/sing-box-rule-set-cn](https://github.com/Dreista/sing-box-rule-set-cn) | 中国大陆域名/IP（每日更新） | .srs |
+
+## 策略组（20 个）
+
+- 节点选择 / 自动选择（urltest）/ 本地直连 / 漏网之鱼
+- 分流组：AI 平台、奈飞视频、油管视频、国际媒体、外服游戏、Steam平台、国内流量、广告拦截
+- 地区节点：香港/美国/日本/新加坡/台湾/韩国（按节点名自动分流）
+
+## 分流规则（16 条，自上而下）
+
+1. 基础：sniff → DNS 劫持 → 内网直连 → 拒 QUIC/BT
+2. 国内直连（Dreista cn/cnip）
+3. 广告拦截（REIJI007）
+4. 流媒体：Netflix/PrimeVideo/HBO/Hulu/AppleTV → 奈飞视频
+5. YouTube → 油管视频
+6. Disney/TikTok/Twitch/Spotify → 国际媒体
+7. AI：OpenAI/Anthropic/Gemini/Copilot → AI 平台
+8. Steam → Steam平台
+9. Epic/PlayStation/Xbox/Nintendo/Riot → 外服游戏
+10. 大厂：Google/Microsoft/Amazon/Adobe → 代理
+11. GFW（cmontage + Dreista filter.txt）→ 代理
+12. 兜底 → 漏网之鱼
+
+## 使用（ShellCrash sing-box）
+
+1. 把 `Custom_All.json` 放到 `$CRASHDIR/templates/`
+2. TUI: `mm` → 6 配置文件管理 → b 本地生成配置文件 → 2 选择规则模版 → 选 Custom_All
+3. 或手动：`sed -i 's|provider_temp_singbox=.*|provider_temp_singbox=/path/to/Custom_All.json|' $CRASHDIR/configs/ShellCrash.cfg`
+
+## 使用（sing-box 原生）
+
+把 `route.rule_set` 的 `path` 改成本地路径，或直接用 remote URL（自动下载更新）。
+
+## 自动更新
+
+GitHub Actions `.github/workflows/auto-update-singbox-all.yml` 每天 UTC 4:00 重新生成模板并提交。
+
+> ⚠️ 注意：规则集总数建议控制在 30 个以内（路由器内存有限）。如需更多分类，编辑 `py/generate_singbox_all.py` 的 `RULE_SETS` 列表自行添加。


### PR DESCRIPTION
## 新增 sing-box ALL 规则集 + 策略组模板

整合 5 个规则仓库的 sing-box 完整配置（20 策略组 + 30 规则集 + 16 分流规则），每日自动更新。

### 规则来源
1. **本仓库** (Aethersailor) - 自定义直连/代理/Steam 基础
2. **senshinya/singbox_ruleset** - blackmatrix7 全集精选（流媒体/游戏/AI/大厂 25 分类）
3. **REIJI007/AdBlock_Rule_For_Sing-box** - 广告拦截（20 分钟更新）
4. **cmontage/proxyrules-cm** - GFW 规则
5. **Dreista/sing-box-rule-set-cn** - 中国大陆域名/IP（每日更新）

### 文件
- `singbox/Custom_All.json` - sing-box 完整模板（remote URL 引用，自动更新）
- `singbox/README.md` - 使用说明
- `py/generate_singbox_all.py` - 模板生成脚本（可自定义规则集列表）
- `.github/workflows/auto-update-singbox-all.yml` - 每天 UTC 4:00 自动更新

### 策略组（20 个）
节点选择/自动选择/本地直连/漏网之鱼 + AI 平台/奈飞视频/油管视频/国际媒体/外服游戏/Steam/国内流量/广告拦截 + 6 地区节点组

### 注意
规则集全部用 remote URL 引用（sing-box 启动时自动下载），不占本地空间；总数 30 个控制在路由器内存范围内。